### PR TITLE
correct ImportError in python 3.x

### DIFF
--- a/rdoclient/rdoclient.py
+++ b/rdoclient/rdoclient.py
@@ -30,7 +30,10 @@ import time
 import uuid
 
 from datetime import datetime
-from Queue import Queue, Empty
+try:
+    from queue import Queue, Empty
+except ImportError:
+    from Queue import Queue, Empty
 
 import requests
 


### PR DESCRIPTION
module is "Queue" in 2.x and "queue" in 3.x.  Tested in 3.x and corrects importError.