### PR TITLE
time.clock() -> time.process_time()

### DIFF
--- a/rdoclient/rdoclient.py
+++ b/rdoclient/rdoclient.py
@@ -2592,7 +2592,7 @@ class RandomOrgClient(object):
         try:
             # Python 2.7
             if self._requests_left is None or \
-               time.clock() > (self._last_response_received_time 
+               time.process_time() > (self._last_response_received_time 
                                + _ALLOWANCE_STATE_REFRESH_SECONDS):
                 self._get_usage()
         except AttributeError:
@@ -2640,7 +2640,7 @@ class RandomOrgClient(object):
         try:
             # Python 2.7
             if self._bits_left is None or \
-            time.clock() > (self._last_response_received_time 
+            time.process_time() > (self._last_response_received_time 
                                    + _ALLOWANCE_STATE_REFRESH_SECONDS):
                 self._get_usage()
         except AttributeError:
@@ -2743,7 +2743,7 @@ class RandomOrgClient(object):
         self._advisory_delay_lock.acquire()
         try:
             # Python 2.7
-            wait = self._advisory_delay - (time.clock() 
+            wait = self._advisory_delay - (time.process_time() 
                                            - self._last_response_received_time)
         except AttributeError:
             # Python 3.3+
@@ -2913,7 +2913,7 @@ class RandomOrgClient(object):
         
         try:
             # Python 2.7
-            self._last_response_received_time = time.clock()
+            self._last_response_received_time = time.process_time()
         except AttributeError: 
             # Python 3.3+
             self._last_response_received_time = time.process_time()


### PR DESCRIPTION
Apparently, time.clock() was removed in Python 3.8.

I followed the advice in https://stackoverflow.com/questions/58569361/attributeerror-module-time-has-no-attribute-clock-in-python-3-8